### PR TITLE
fix: remove duplicate /api prefix from all service endpoints

### DIFF
--- a/services/auth/forgot-password.service.ts
+++ b/services/auth/forgot-password.service.ts
@@ -13,7 +13,7 @@ import { AxiosError } from "axios";
  */
 export const forgotPassword = async (data: ForgotPasswordRequest): Promise<MessageResponse> => {
   try {
-    const response = await apiClient.post<MessageResponse>("/api/auth/forgot-password", data);
+    const response = await apiClient.post<MessageResponse>("/auth/forgot-password", data);
     return response.data;
   } catch (error: unknown) {
     if (error instanceof AxiosError) {

--- a/services/auth/logout.service.ts
+++ b/services/auth/logout.service.ts
@@ -12,7 +12,7 @@ import { AxiosError } from "axios";
  */
 export const logoutUser = async (): Promise<MessageResponse> => {
   try {
-    const response = await apiClient.post<MessageResponse>("/api/auth/logout");
+    const response = await apiClient.post<MessageResponse>("/auth/logout");
     return response.data;
   } catch (error: unknown) {
     if (error instanceof AxiosError) {

--- a/services/auth/refresh-token.service.ts
+++ b/services/auth/refresh-token.service.ts
@@ -20,7 +20,7 @@ interface RefreshTokenResponse {
 export const refreshAccessToken = async (refreshToken: string): Promise<RefreshTokenResponse> => {
   try {
     const response = await axios.post<RefreshTokenResponse>(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/auth/refresh`,
+      `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
       { refreshToken },
       {
         headers: {

--- a/services/auth/register.service.ts
+++ b/services/auth/register.service.ts
@@ -13,7 +13,7 @@ import { AxiosError } from "axios";
  */
 export const registerUser = async (data: RegisterRequest): Promise<RegisterResponse> => {
   try {
-    const response = await apiClient.post<RegisterResponse>("/api/auth/register", data);
+    const response = await apiClient.post<RegisterResponse>("/auth/register", data);
     return response.data;
   } catch (error: unknown) {
     if (error instanceof AxiosError) {

--- a/services/auth/reset-password.service.ts
+++ b/services/auth/reset-password.service.ts
@@ -13,7 +13,7 @@ import { AxiosError } from "axios";
  */
 export const resetPassword = async (data: ResetPasswordRequest): Promise<MessageResponse> => {
   try {
-    const response = await apiClient.post<MessageResponse>("/api/auth/reset-password", data);
+    const response = await apiClient.post<MessageResponse>("/auth/reset-password", data);
     return response.data;
   } catch (error: unknown) {
     if (error instanceof AxiosError) {
@@ -39,7 +39,7 @@ export const validateResetToken = async (token: string): Promise<boolean> => {
   try {
     // Gửi request với token và password giả để kiểm tra token
     // Server sẽ trả về lỗi nếu token không hợp lệ
-    await apiClient.post<MessageResponse>("/api/auth/validate-reset-token", { token });
+    await apiClient.post<MessageResponse>("/auth/validate-reset-token", { token });
     return true;
   } catch (error: unknown) {
     return false;

--- a/services/auth/signin.service.ts
+++ b/services/auth/signin.service.ts
@@ -13,7 +13,7 @@ import { AxiosError } from "axios";
  */
 export const signInUser = async (data: SignInRequest): Promise<SignInResponse> => {
   try {
-    const response = await apiClient.post<SignInResponse>("/api/auth/signin", data);
+    const response = await apiClient.post<SignInResponse>("/auth/signin", data);
     return response.data;
   } catch (error: unknown) {
     if (error instanceof AxiosError) {

--- a/services/mindmap/mindmap.service.ts
+++ b/services/mindmap/mindmap.service.ts
@@ -11,7 +11,7 @@ import {
  * Service for Mindmap API operations
  */
 
-const MINDMAP_API_BASE = '/api/mindmaps';
+const MINDMAP_API_BASE = '/mindmaps';
 
 /**
  * Create a new mindmap


### PR DESCRIPTION
- Fix URL duplication issue: /api/api/auth/register -> /api/auth/register
- Update all auth services: register, signin, logout, forgot-password, reset-password, refresh-token
- Update mindmap service base path
- baseURL already includes /api, so endpoints should not have /api prefix