### PR TITLE
fix: Resolve JSON parse error in Thinking mode streaming

### DIFF
--- a/components/ai/AiComposer.tsx
+++ b/components/ai/AiComposer.tsx
@@ -229,21 +229,12 @@ export default function AiComposer({ defaultOpen = false }: { defaultOpen?: bool
             }
 
             console.log('[AI Composer] Calling /ai/thinking/otmz with', thinkingReq)
-            // Pass mindmapId as query parameter for streaming
-            const otmzUrl = `/ai/thinking/otmz${mindmap.id ? `?mindmapId=${mindmap.id}` : ''}`
-            const otmz: Otmz = await fetch(otmzUrl, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(thinkingReq),
-            }).then(r => r.json())
+            // Pass mindmapId to enable streaming
+            const otmz: Otmz = await createThinkingOtmz(thinkingReq, mindmap.id)
 
             console.log('[AI Composer] OTMZ received, calling /ai/thinking/actions')
-            const actionsUrl = `/ai/thinking/actions${mindmap.id ? `?mindmapId=${mindmap.id}` : ''}`
-            const actionsRes: ActionList = await fetch(actionsUrl, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(otmz),
-            }).then(r => r.json())
+            // Pass mindmapId to enable streaming
+            const actionsRes: ActionList = await getThinkingActions(otmz, effectiveLang, mindmap.id)
 
             // Note: Streaming messages are already displayed via WebSocket listeners
             // No need to add additional messages here to avoid duplicates

--- a/services/ai/ai.service.ts
+++ b/services/ai/ai.service.ts
@@ -176,7 +176,7 @@ export function openGenerateStream(onData: (chunk: any) => void, onEnd?: () => v
   }
   es.onerror = (e) => { onError?.(e); es.close() }
   es.onopen = () => { /* connected */ }
-  ;(es as any).onend = () => { onEnd?.(); es.close() }
+    ; (es as any).onend = () => { onEnd?.(); es.close() }
   return es
 }
 
@@ -188,11 +188,12 @@ export async function generateMindmapProject(payload: { topic: string; mode?: st
 // ===== Thinking Mode API calls =====
 
 // POST /api/ai/thinking/otmz
-export async function createThinkingOtmz(body: ThinkingModeRequest): Promise<Otmz> {
+export async function createThinkingOtmz(body: ThinkingModeRequest, mindmapId?: string): Promise<Otmz> {
   const res = await apiClient.post<Otmz>('/ai/thinking/otmz', body, {
     headers: {
       Accept: 'application/json',
     },
+    params: mindmapId ? { mindmapId } : undefined,
   })
   return res.data
 }
@@ -210,13 +211,17 @@ export async function getThinkingPrompt(query: ThinkingModeRequest): Promise<any
 }
 
 // POST /api/ai/thinking/actions
-// Body: Otmz, Query: language?
-export async function getThinkingActions(otmz: Otmz, language?: string): Promise<ActionList> {
+// Body: Otmz, Query: language?, mindmapId?
+export async function getThinkingActions(otmz: Otmz, language?: string, mindmapId?: string): Promise<ActionList> {
+  const params: any = {}
+  if (language) params.language = language
+  if (mindmapId) params.mindmapId = mindmapId
+
   const res = await apiClient.post<ActionList>('/ai/thinking/actions', otmz, {
     headers: {
       Accept: 'application/json',
     },
-    params: language ? { language } : undefined,
+    params: Object.keys(params).length > 0 ? params : undefined,
   })
   return res.data
 }


### PR DESCRIPTION
- Update createThinkingOtmz() to accept optional mindmapId parameter
- Update getThinkingActions() to accept optional mindmapId parameter
- Revert AIComposer to use service methods instead of raw fetch
- Service methods properly handle base URL via apiClient