### PR TITLE
fix: Add authentication to Generator endpoint call

### DIFF
--- a/components/ai/AiComposer.tsx
+++ b/components/ai/AiComposer.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuSub, DropdownMenuSubTrigger, DropdownMenuSubContent, DropdownMenuRadioGroup, DropdownMenuRadioItem } from "@/components/ui/dropdown-menu"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { optimizeMindmapByAI } from "@/services/mindmap/mindmap.service"
-import { createThinkingOtmz, getThinkingActions, type ThinkingModeRequest, type Otmz, type ActionList } from "@/services/ai/ai.service"
+import { createThinkingOtmz, getThinkingActions, generateMindmapFromActions, type ThinkingModeRequest, type Otmz, type ActionList } from "@/services/ai/ai.service"
 import { useAuth } from "@/hooks/auth/useAuth"
 import { getUserProfile } from "@/services/auth/update-user.service"
 import { getSocket } from "@/lib/realtime"
@@ -238,19 +238,9 @@ export default function AiComposer({ defaultOpen = false }: { defaultOpen?: bool
             const actionsRes: ActionList = await getThinkingActions(otmz, effectiveLang, mindmap.id)
 
             console.log('[AI Composer] Step 3: Calling Generator (Execute)')
-            // Step 3: Generator - execute ActionList to create mindmap
+            // Step 3: Generator - execute ActionList to create mindmap (with authentication)
             const structType = otmz?.meta?.structureType || structureType || 'mindmap'
-            const generatorResponse = await fetch(`/api/ai/thinking/generate?mindmapId=${mindmap.id}&structureType=${structType}`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(actionsRes),
-            })
-
-            if (!generatorResponse.ok) {
-              throw new Error('Generator failed')
-            }
-
-            const generatedMindmap = await generatorResponse.json()
+            const generatedMindmap = await generateMindmapFromActions(actionsRes, mindmap.id, structType)
             console.log('[AI Composer] Mindmap generated:', generatedMindmap)
 
             // Reload mindmap to show new nodes (same as Normal mode)

--- a/services/ai/ai.service.ts
+++ b/services/ai/ai.service.ts
@@ -226,3 +226,21 @@ export async function getThinkingActions(otmz: Otmz, language?: string, mindmapI
   return res.data
 }
 
+// POST /api/ai/thinking/generate
+// Body: ActionList, Query: mindmapId, structureType?
+export async function generateMindmapFromActions(
+  actionList: ActionList,
+  mindmapId: string,
+  structureType?: string
+): Promise<MindmapResponse> {
+  const params: any = { mindmapId }
+  if (structureType) params.structureType = structureType
+
+  const res = await apiClient.post<MindmapResponse>('/ai/thinking/generate', actionList, {
+    headers: {
+      Accept: 'application/json',
+    },
+    params,
+  })
+  return res.data
+}


### PR DESCRIPTION
- Create generateMindmapFromActions service method using apiClient
- apiClient automatically includes X-User-Id header for authentication
- Replace raw fetch with service method in AIComposer
- Fixes 'Generator failed' error due to missing authentication