### PR TITLE
fix: Simplify message badges to show only mode names

### DIFF
--- a/components/ai/AiComposer.tsx
+++ b/components/ai/AiComposer.tsx
@@ -481,10 +481,10 @@ export default function AiComposer({ defaultOpen = false }: { defaultOpen?: bool
                         {m.text}
                       </div>
                       {m.role === "user" && m.mode ? (
-                        <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                          {m.mode === "max" && "AI tối ưu với độ chi tiết cao (-2 credits)"}
-                          {m.mode === "thinking" && "Phân tích sâu và tối ưu hóa (-3 credits)"}
-                          {m.mode === "normal" && "Tạo nhanh với cấu trúc chuẩn (-1 credit)"}
+                        <div className="text-[11px] text-muted-foreground">
+                          {m.mode === "max" && "Max Mode"}
+                          {m.mode === "thinking" && "Thinking Mode"}
+                          {m.mode === "normal" && "Normal Mode"}
                         </div>
                       ) : null}
                     </div>


### PR DESCRIPTION
- Remove credit costs from message badges
- Show only 'Thinking Mode', 'Normal Mode', 'Max Mode'
- Cleaner UI without distracting credit info