### PR TITLE
feat: add page refresh on permission change

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -52,6 +52,8 @@ function EditorInner() {
     setFullMindmapState,
     accessRevoked,
     clearAccessRevoked,
+    permissionChanged,
+    clearPermissionChanged,
   } = useMindmapContext()
 
   const { toast } = useToast()
@@ -123,6 +125,20 @@ function EditorInner() {
       router.push('/')
     }
   }, [accessRevoked, clearAccessRevoked, router, toast])
+
+  // Handle permission change - refresh page when permissions change
+  useEffect(() => {
+    if (permissionChanged?.changed) {
+      console.log('[Editor] Permission changed, refreshing page:', permissionChanged)
+      toast({
+        title: 'Permission Changed',
+        description: `Your access level has been updated. Refreshing page...`,
+      })
+      clearPermissionChanged()
+      // Refresh the page to get updated permissions
+      window.location.reload()
+    }
+  }, [permissionChanged, clearPermissionChanged, toast])
 
   // Load collaborators when mindmap is loaded
   useEffect(() => {

--- a/app/public-mindmap/page.tsx
+++ b/app/public-mindmap/page.tsx
@@ -34,6 +34,8 @@ function PublicMindmapInner() {
     saveMindmap,
     accessRevoked,
     clearAccessRevoked,
+    permissionChanged,
+    clearPermissionChanged,
   } = useMindmapContext()
 
   const { toast } = useToast()
@@ -102,6 +104,20 @@ function PublicMindmapInner() {
       router.push('/')
     }
   }, [accessRevoked, clearAccessRevoked, router, toast])
+
+  // Handle permission change - refresh page when permissions change
+  useEffect(() => {
+    if (permissionChanged?.changed) {
+      console.log('[PublicMindmap] Permission changed, refreshing page:', permissionChanged)
+      toast({
+        title: 'Permission Changed',
+        description: `Your access level has been updated. Refreshing page...`,
+      })
+      clearPermissionChanged()
+      // Refresh the page to get updated permissions
+      window.location.reload()
+    }
+  }, [permissionChanged, clearPermissionChanged, toast])
 
   const handleTitleChange = (newTitle: string) => {
     setTitle(newTitle)


### PR DESCRIPTION
- Add permissionChanged state to MindmapContext for tracking permission updates
- Listen for mindmap:public:permission:changed and mindmap:collaborator:role:changed events
- Refresh public-mindmap page when public access level changes (view/edit)
- Refresh editor page when collaborator role changes (EDITOR/VIEWER)